### PR TITLE
Related to - https://github.com/wordpress-premium/advanced-custom-fie…

### DIFF
--- a/includes/class-acf-data.php
+++ b/includes/class-acf-data.php
@@ -93,7 +93,17 @@ if ( ! class_exists( 'ACF_Data' ) ) :
 		 * @return  type Description.
 		 */
 		function _key( $name = '' ) {
-			return isset( $this->aliases[ $name ] ) ? $this->aliases[ $name ] : $name;
+			// Check if $name is a valid array key type
+			if (!is_string($name) && !is_int($name)) {
+				return $name;
+			}
+
+			// Check if aliases property is an array and the key exists
+			if (is_array($this->aliases) && isset($this->aliases[$name])) {
+				return $this->aliases[$name];
+			}
+
+			return $name;
 		}
 
 		/**
@@ -139,16 +149,20 @@ if ( ! class_exists( 'ACF_Data' ) ) :
 		 * @return  mixed
 		 */
 		function get( $name = false ) {
-
 			// Get all.
 			if ( $name === false ) {
 				return $this->data;
-
-				// Get specific.
-			} else {
-				$key = $this->_key( $name );
-				return isset( $this->data[ $key ] ) ? $this->data[ $key ] : null;
 			}
+
+			// Get specific.
+			$key = $this->_key( $name );
+
+			// Check if $key is a valid array key type and data exists
+			if ((is_string($key) || is_int($key)) && is_array($this->data) && isset($this->data[$key])) {
+				return $this->data[$key];
+			}
+
+			return null;
 		}
 
 		/**


### PR DESCRIPTION
…lds-pro/pull/10

Fixes: 

TypeError
Cannot access offset of type array in isset or empty search► File: .../advanced-custom-fields-pro/includes/class-acf-data.php:101

 91:             * Returns a key for the given name allowing aliasses to work.
 92:             *
 93:             * @date    18/1/19
 94:             * @since   5.7.10
 95:             *
 96:             * @param   type $var Description. Default.
 97:             * @return  type Description.
 98:             */
 99:            function _key($name = '')
100:            {
101:                return isset($this->aliases[$name]) ? $this->aliases[$name] : $name;

102:            }