### PR TITLE
Fix dynamic properties deprecation php 8.2

### DIFF
--- a/acf.php
+++ b/acf.php
@@ -50,7 +50,7 @@ if (!class_exists("ACF")) {
 	/**
 	 * The main ACF class
 	 */
-    #[AllowDynamicProperties]
+        #[AllowDynamicProperties]
 	class ACF
 	{
 		/**

--- a/acf.php
+++ b/acf.php
@@ -50,6 +50,7 @@ if (!class_exists("ACF")) {
 	/**
 	 * The main ACF class
 	 */
+    #[AllowDynamicProperties]
 	class ACF
 	{
 		/**


### PR DESCRIPTION
Fixes `Deprecated: Creation of dynamic property ACF::$fields is deprecated in /wp-content/plugins/advanced-custom-fields/includes/fields.php on line 117` and many other warnings when using php 8.2